### PR TITLE
Improve notifications

### DIFF
--- a/include/buttonmatrix/ButtonHandler.h
+++ b/include/buttonmatrix/ButtonHandler.h
@@ -17,85 +17,77 @@ namespace BusDashboard {
          * enum of all buttons on the dashboard with a mapping to their position on the button matrix
 		 * note: sorry for the missing translation, I may add it sometimes ...
          */
-		class MatrixPosition
+		enum class MatrixPosition : uint8_t
 		{
-			public:
-				enum Value : uint8_t
-				{
-					// buttons and switches on the right half of the dashboard
-					Gangschaltung_D = 1,
-					Gangschaltung_N,
-					Gangschaltung_R,
-					Tuer_3,
-					Tuer_Freigabe,
-					Tuer_2,
-					Tuer_1,
-					Tuer_Sperren_1,
-					Tuer_Sperren_2,
-					Kneeling_2_auf,
-					Kneeling_2_ab,
-					Kneeling_1_auf,
-					Kneeling_1_ab,
-					Kindersteuerung_1,
-					Kindersteuerung_2,
-					Haltestellenbremse,
-					Parkbremse,		// Quit
-					SystemInfo_auf, // Profil_Wechseln
-					SystemInfo_ab,
-					Reset,
-					Display,
+			// buttons and switches on the right half of the dashboard
+			Gangschaltung_D = 1,
+			Gangschaltung_N,
+			Gangschaltung_R,
+			Tuer_3,
+			Tuer_Freigabe,
+			Tuer_2,
+			Tuer_1,
+			Tuer_Sperren_1,
+			Tuer_Sperren_2,
+			Kneeling_2_auf,
+			Kneeling_2_ab,
+			Kneeling_1_auf,
+			Kneeling_1_ab,
+			Kindersteuerung_1,
+			Kindersteuerung_2,
+			Haltestellenbremse,
+			Parkbremse,		// Quit
+			SystemInfo_auf, // Profil_Wechseln
+			SystemInfo_ab,
+			Reset,
+			Display,
 
-					// ignition / lock
-					Zuendung_1,
-					Zuendung_2,
-					Zuendung_3,
+			// ignition / lock
+			Zuendung_1,
+			Zuendung_2,
+			Zuendung_3,
 
-					// retarder
-					Retarder_1,
-					Retarder_2,
-					Retarder_3,
-					Retarder_4,
-					Retarder_5,
-					Retarder_6,
+			// retarder
+			Retarder_1,
+			Retarder_2,
+			Retarder_3,
+			Retarder_4,
+			Retarder_5,
+			Retarder_6,
 
-					// direction-indicator control
-					Scheibenwischer_1,
-					Scheibenwischer_2,
-					Scheibenwischer_3,
-					Wischwasser,
-					Hupe,
-					Licht_Fern,
-					Blinker_Links,
-					Blinker_Rechts,
+			// direction-indicator control
+			Scheibenwischer_1,
+			Scheibenwischer_2,
+			Scheibenwischer_3,
+			Wischwasser,
+			Hupe,
+			Licht_Fern,
+			Blinker_Links,
+			Blinker_Rechts,
 
-					// buttons and switches on the left half of the dashboard
-					Haltestellenansage,
-					Blinker_Warn,
-					Licht_Fahrer,
-					Licht_Innen_1,
-					Licht_Innen_2,
-					Asr,
+			// buttons and switches on the left half of the dashboard
+			Haltestellenansage,
+			Blinker_Warn,
+			Licht_Fahrer,
+			Licht_Innen_1,
+			Licht_Innen_2,
+			Asr,
 
-					// light control
-					/*Licht_Abblend,
-					Licht_Standlicht,
-					Licht_Nebelschluss, */
-					Scheinwerfer_A1,
-					Scheinwerfer_A2,
-					Scheinwerfer_I1,
-					Scheinwerfer_I2,
+			// light control
+			/*Licht_Abblend,
+			Licht_Standlicht,
+			Licht_Nebelschluss, */
+			Scheinwerfer_A1,
+			Scheinwerfer_A2,
+			Scheinwerfer_I1,
+			Scheinwerfer_I2,
 
-				};
-				MatrixPosition() = default;
-				constexpr MatrixPosition(Value aFruit) : value(aFruit) {}
-				/*
-				constexpr bool operator==(MatrixPosition a) const { return value == MatrixPosition.value; }
-				constexpr bool operator!=(MatrixPosition a) const { return value != MatrixPosition.value; }
-				*/
-				uint8_t toUint8_t() { return value; }
+		};
 
-			private:
-				Value value;
+		enum class NotificationType : uint8_t
+		{
+			ALL,		 // notify the listener each time the hardware is read
+			CHANGES_ONLY // notify the listener only when the hardware state changes
 		};
 
 		static const uint8_t MATRIX_ROW_COUNT = 8; // the number of rows in the multiplexer matrix
@@ -109,8 +101,16 @@ namespace BusDashboard {
 		 * the listeners get notified of the current state each time a button is scanned
 		 * @param[in] listener the listener instance to add
 		 * @param[in] button the button the listener wants to be informed about (button number on the scan matrix)
+		 * @param[in] mode what the listener wants to be notified of
 		*/
-		bool addListener(ButtonListener &listener, const uint8_t button);
+		bool addListener(ButtonListener &listener, const MatrixPosition button);
+
+		/**
+		 * gives the state the button was in on the last read
+		 * Note: this is the cheapest way RAM-wise to store the previous button state
+		 * WARNING: double check that button is within in the allowed range!
+		*/
+		bool previousState(const uint8_t button);
 
 		/**
 		 * queries the current state of connected buttons and notifies listeners
@@ -128,12 +128,13 @@ namespace BusDashboard {
 
 	protected:
 	private:
-		const uint8_t _pin_cs;		   // SPI: the Arduino pin the button matrix CS is connected to
-		const uint8_t _address = 0x20; // SPI: A0 .. A2 connected to ground
+		const uint8_t _pin_cs;		                       // SPI: the Arduino pin the button matrix CS is connected to
+		const uint8_t _address = 0x20;                     // SPI: A0 .. A2 connected to ground
 		ItemNode<ButtonListener> *_listener[BUTTON_COUNT]; // registered listeners
-		uint8_t _row = 0; // the current row (this row gets queried on updateStatus)
-		unsigned long _lastButtonChange = 0; // timestamp: last change in a button state
-		unsigned long _lastRead = 0;  // timestamp: last read action (for throtteling the read frequency)
+		uint8_t _row = 0;								   // the current row (this row gets queried on updateStatus)
+		unsigned long _lastButtonChange = 0;			   // timestamp: last change in a button state
+		unsigned long _lastRead = 0;					   // timestamp: last read action (for throtteling the read frequency)
+		bool _prevState[BUTTON_COUNT];					   // the state the button was in on last read attempt
 
 		gpio_MCP23S17* _mcp;
 
@@ -165,11 +166,11 @@ namespace BusDashboard {
 		}
 
 		/**
-		 * notifies all listeners of the current value for a button (only to be called from within updateStatus())
+		 * notifies all listeners of the current and the previous value for a button (only to be called from within updateStatus())
          * @param[in] button this button has been read
-         * @param[in] state this is the state that has been read
+         * @param[in] state this is the state that has been read now
 		 */
-		void notify(const uint8_t button, const bool state);
+		void notify(const uint8_t button, const bool current_state);
 
 		ButtonHandler() = delete;
         ButtonHandler(const ButtonHandler&) = delete;

--- a/include/buttonmatrix/ButtonListener.h
+++ b/include/buttonmatrix/ButtonListener.h
@@ -1,6 +1,5 @@
 #pragma once
 #include <Arduino.h>
-//#include "buttonmatrix/ButtonHandler.h"
 
 namespace BusDashboard {
 
@@ -15,10 +14,11 @@ namespace BusDashboard {
 		/**
 		this gets called every time a button state is read from the muxer hardware
 		@param[in] button the button that has been read
-		@param[in] state the state the button was in (true: connected / pressed)
+		@param[in] state the state the button is in (true: connected / pressed)
+		@param[in] state the state the button was in last time it was read
 		@returns true, if the state has changed
 		*/
-		virtual bool setCurrentState(const uint8_t button, const bool state) = 0;
+		virtual void setCurrentState(const uint8_t button, const bool state, const bool prev_state) = 0;
 		virtual void registerWith(ButtonHandler &bh) = 0;
 		virtual void begin() = 0;
 	};

--- a/include/dashboard/LightControl.h
+++ b/include/dashboard/LightControl.h
@@ -4,14 +4,13 @@
 
 namespace BusDashboard
 {
-    class Dashboard;
     class ButtonHandler;
 
     class LightControl : public ButtonListener
     {
     public:
         LightControl();
-        bool setCurrentState(const uint8_t button, const bool state);
+        void setCurrentState(const uint8_t button, const bool state, const bool prev_state);
         void registerWith(ButtonHandler &bh);
         void begin() {};
         bool isLit() { return _dashboardLit; }
@@ -20,14 +19,6 @@ namespace BusDashboard
     private:
         static uint8_t const WAIT_MAX_MS_IN_LEAVING_STATE_MS = 50;
         static uint8_t const WAIT_FOR_OFF_BLINK_DELAY_MS = 250;
-        enum class Index : uint8_t
-        {
-            A1,
-            A2,
-            I1,
-            I2
-        };
-        static uint8_t const MaxIndex = (uint8_t)Index::A2;
         enum class State : uint8_t
         {
             Undefined,    // before initialization, never reached afterwards
@@ -42,7 +33,6 @@ namespace BusDashboard
             I2,           // lighting control knob is in position "I2"
             I2_leaving    // I2 has changed to LOW but no other knob position is measured HIGH yet
         };
-        bool _isConnected[MaxIndex + 1];
         State _currentState = State::Undefined;
         unsigned long _leavingTS = 0;
         unsigned long _blinkTS = 0;

--- a/include/dashboard/Shifter.h
+++ b/include/dashboard/Shifter.h
@@ -2,44 +2,27 @@
 #include <Arduino.h>
 #include "buttonmatrix/ButtonListener.h"
 
-// ToDo: implement state machine to handle "all off" gracefully (without sending lots of "n")
-
 namespace BusDashboard {
-
-    class Dashboard;
 
     class Shifter : public ButtonListener
     {
     public:
-        bool setCurrentState(const uint8_t button, const bool state);
+        void setCurrentState(const uint8_t button, const bool state, const bool prev_state);
         void registerWith(ButtonHandler &bh);
         Shifter();
         void begin() {};
 
     protected:
+
     private:
         enum class State
         {
             Undefined,
-            Off,
-            D,
-            D_leaving,
             R,
-            R_leaving,
             N,
-            N_leaving
+            D
         };
-
-        enum class Index
-        {
-            D = 0,
-            R = 1,
-            N = 2
-        };
-        static const uint8_t MAX_INDEX = (uint8_t)Index::N;
-        State _currentState = State::Undefined;
-        bool _state[MAX_INDEX + 1];
-        bool _charToSend[MAX_INDEX + 1];
+        State _state = State::Undefined;
         bool _initDone = false;
         unsigned long _lastBlinkToggle = 0;
 

--- a/include/debug/LampTester.h
+++ b/include/debug/LampTester.h
@@ -4,7 +4,7 @@
 namespace BusDashboard {
     class LampTester : public ButtonListener {
         public:
-            bool setCurrentState(const uint8_t button, const bool state);
+            void setCurrentState(const uint8_t button, const bool state, bool prev_state);
             void registerWith(ButtonHandler &bh);
             LampTester();
             void begin() {}

--- a/src/dashboard/LightControl.cpp
+++ b/src/dashboard/LightControl.cpp
@@ -15,13 +15,11 @@ namespace BusDashboard
     void LightControl::setCurrentState(const uint8_t button, const bool state, const bool prev_state)
     {
         bool _isConnected = prev_state;
-        bool resetTimer = false;
         switch (button)
         {
         case (uint8_t)ButtonHandler::MatrixPosition::Scheinwerfer_A1:
             if (_isConnected != state)
             {
-                resetTimer = true;
                 if (state)
                 {
                     switch (_currentState)
@@ -56,7 +54,6 @@ namespace BusDashboard
         case (uint8_t)ButtonHandler::MatrixPosition::Scheinwerfer_A2:
             if (_isConnected != state)
             {
-                resetTimer = true;
                 if (state)
                 {
                     switch (_currentState)
@@ -89,7 +86,6 @@ namespace BusDashboard
         case (uint8_t)ButtonHandler::MatrixPosition::Scheinwerfer_I1:
             if (_isConnected != state)
             {
-                resetTimer = true;
                 if (state)
                 {
                     switch (_currentState)
@@ -122,7 +118,6 @@ namespace BusDashboard
         case (uint8_t)ButtonHandler::MatrixPosition::Scheinwerfer_I2:
             if (_isConnected != state)
             {
-                resetTimer = true;
                 if (state)
                 {
                     switch (_currentState)

--- a/src/dashboard/LightControl.cpp
+++ b/src/dashboard/LightControl.cpp
@@ -10,25 +10,17 @@
 
 namespace BusDashboard
 {
-    LightControl::LightControl()
-    {
-        _isConnected[(uint8_t)Index::A1] = false;
-        _isConnected[(uint8_t)Index::A2] = false;
-        _isConnected[(uint8_t)Index::I1] = false;
-        _isConnected[(uint8_t)Index::I2] = false;
-    }
+    LightControl::LightControl() {}
 
-    bool LightControl::setCurrentState(const uint8_t button, const bool state)
+    void LightControl::setCurrentState(const uint8_t button, const bool state, const bool prev_state)
     {
+        bool _isConnected = prev_state;
         bool resetTimer = false;
-        uint8_t index;
         switch (button)
         {
-        case ButtonHandler::MatrixPosition::Scheinwerfer_A1:
-            index = (uint8_t)Index::A1;
-            if (_isConnected[index] != state)
+        case (uint8_t)ButtonHandler::MatrixPosition::Scheinwerfer_A1:
+            if (_isConnected != state)
             {
-                _isConnected[index] = state;
                 resetTimer = true;
                 if (state)
                 {
@@ -61,11 +53,9 @@ namespace BusDashboard
             }
             break;
 
-        case ButtonHandler::MatrixPosition::Scheinwerfer_A2:
-            index = (uint8_t)Index::A2;
-            if (_isConnected[index] != state)
+        case (uint8_t)ButtonHandler::MatrixPosition::Scheinwerfer_A2:
+            if (_isConnected != state)
             {
-                _isConnected[index] = state;
                 resetTimer = true;
                 if (state)
                 {
@@ -96,11 +86,9 @@ namespace BusDashboard
             }
             break;
 
-        case ButtonHandler::MatrixPosition::Scheinwerfer_I1:
-            index = (uint8_t)Index::I1;
-            if (_isConnected[index] != state)
+        case (uint8_t)ButtonHandler::MatrixPosition::Scheinwerfer_I1:
+            if (_isConnected != state)
             {
-                _isConnected[index] = state;
                 resetTimer = true;
                 if (state)
                 {
@@ -131,11 +119,9 @@ namespace BusDashboard
             }
             break;
 
-        case ButtonHandler::MatrixPosition::Scheinwerfer_I2:
-            index = (uint8_t)Index::I2;
-            if (_isConnected[index] != state)
+        case (uint8_t)ButtonHandler::MatrixPosition::Scheinwerfer_I2:
+            if (_isConnected != state)
             {
-                _isConnected[index] = state;
                 resetTimer = true;
                 if (state)
                 {
@@ -205,7 +191,6 @@ namespace BusDashboard
             break;
         }
         
-        return resetTimer;
     }
 
     void LightControl::registerWith(ButtonHandler &bh)

--- a/src/dashboard/Shifter.cpp
+++ b/src/dashboard/Shifter.cpp
@@ -14,68 +14,59 @@ namespace BusDashboard
 {
     Shifter::Shifter()
     {
-        uint8_t index = (uint8_t)Index::D;
-        _state[index] = false;
-        _charToSend[index] = 'd';
-
-        index = (uint8_t)Index::R;
-        _state[index] = false;
-        _charToSend[index] = 'r';
-
-        index = (uint8_t)Index::N;
-        _state[index] = false;
-        _charToSend[index] = 'n';
     }
 
-    bool Shifter::setCurrentState(const uint8_t button, const bool state)
+    void Shifter::setCurrentState(const uint8_t button, const bool state, const bool prev_state)
     {
-        uint8_t index;
-        switch (button)
-        {
-        case ButtonHandler::MatrixPosition::Gangschaltung_D:
-            index = (uint8_t)Index::D;
-            break;
-        case ButtonHandler::MatrixPosition::Gangschaltung_R:
-            index = (uint8_t)Index::R;
-            break;
-        case ButtonHandler::MatrixPosition::Gangschaltung_N:
-            index = (uint8_t)Index::N;
-            break;
-        default:
-            index = MAX_INDEX+1;
-            break;
-        }
+        State targetState;
 
-        bool changed;
-        if (index <= MAX_INDEX)
+        if (state != prev_state)
         {
-            changed = _state[index] != state;
-            if (changed)
+            switch (button)
             {
-                _state[index] = state;
+            case (uint8_t)ButtonHandler::MatrixPosition::Gangschaltung_D:
                 if (state)
-                {
-                    Dashboard::instance().keyboardHandler().addPressReleaseAction(_charToSend[index]);
-                }
+                    targetState = State::D;
+                else
+                    targetState = State::N;
+                break;
+            case (uint8_t)ButtonHandler::MatrixPosition::Gangschaltung_R:
+                if (state)
+                    targetState = State::R;
+                else
+                    targetState = State::N;
+                break;
+            case (uint8_t)ButtonHandler::MatrixPosition::Gangschaltung_N:
+                if (state)
+                    targetState = State::N;
+                break;
+            default:
+                break;
             }
         }
-        else
-        {
-            changed = false;
-        }
 
-        // it is possible to switch all three buttons off (which should not happen) -> if that's the case alert the dashboard
-        //   we cannot have the switch blink, because the pcb lights only the pressed button ...
-        if (!(_state[(uint8_t)Index::D] | _state[(uint8_t)Index::R] | _state[(uint8_t)Index::N]))
+        if (targetState != _state)
         {
-            index = (uint8_t)Index::N;
-            _state[index] = true;
-            Dashboard::instance().keyboardHandler().addPressReleaseAction(_charToSend[index]);
+            char charToSend;
+            switch (targetState)
+            {
+            case State::D:
+                charToSend = 'd';
+                break;
+            case State::N:
+                charToSend = 'n';
+                break;
+            case State::R:
+                charToSend = 'r';
+                break;
+            case State::Undefined:
+                charToSend = 0;
+                break;
+            }
+            if (charToSend >0) Dashboard::instance().keyboardHandler().addPressReleaseAction(charToSend);
+            targetState = _state;
         }
-
         Dashboard::instance().lampHandler().setState(LampHandler::DriverPosition::Gangschaltung, Dashboard::instance().isLit());
-
-        return changed;
     }
 
     void Shifter::registerWith(ButtonHandler &bh)

--- a/src/debug/LampTester.cpp
+++ b/src/debug/LampTester.cpp
@@ -8,22 +8,66 @@ namespace BusDashboard {
     void LampTester::registerWith(ButtonHandler &bh)
     {
         // add a test listener to all buttons
-        for (uint8_t button = 0; button < LampHandler::NUMBER_OF_ICS * 8; button++)
-        {
-            bh.addListener(*this, button);
-        }
+        bh.addListener(*this, ButtonHandler::MatrixPosition::Asr);
+        bh.addListener(*this, ButtonHandler::MatrixPosition::Blinker_Links);
+        bh.addListener(*this, ButtonHandler::MatrixPosition::Blinker_Rechts);
+        bh.addListener(*this, ButtonHandler::MatrixPosition::Blinker_Warn);
+        bh.addListener(*this, ButtonHandler::MatrixPosition::Display);
+        bh.addListener(*this, ButtonHandler::MatrixPosition::Gangschaltung_D);
+        bh.addListener(*this, ButtonHandler::MatrixPosition::Gangschaltung_N);
+        bh.addListener(*this, ButtonHandler::MatrixPosition::Gangschaltung_R);
+        bh.addListener(*this, ButtonHandler::MatrixPosition::Haltestellenansage);
+        bh.addListener(*this, ButtonHandler::MatrixPosition::Haltestellenbremse);
+        bh.addListener(*this, ButtonHandler::MatrixPosition::Hupe);
+        bh.addListener(*this, ButtonHandler::MatrixPosition::Kindersteuerung_1);
+        bh.addListener(*this, ButtonHandler::MatrixPosition::Kindersteuerung_2);
+        bh.addListener(*this, ButtonHandler::MatrixPosition::Kneeling_1_ab);
+        bh.addListener(*this, ButtonHandler::MatrixPosition::Kneeling_1_auf);
+        bh.addListener(*this, ButtonHandler::MatrixPosition::Kneeling_2_ab);
+        bh.addListener(*this, ButtonHandler::MatrixPosition::Kneeling_2_auf);
+        bh.addListener(*this, ButtonHandler::MatrixPosition::Licht_Fahrer);
+        bh.addListener(*this, ButtonHandler::MatrixPosition::Licht_Fern);
+        bh.addListener(*this, ButtonHandler::MatrixPosition::Licht_Innen_1);
+        bh.addListener(*this, ButtonHandler::MatrixPosition::Licht_Innen_2);
+        bh.addListener(*this, ButtonHandler::MatrixPosition::Parkbremse);
+        bh.addListener(*this, ButtonHandler::MatrixPosition::Reset);
+        bh.addListener(*this, ButtonHandler::MatrixPosition::Retarder_1);
+        bh.addListener(*this, ButtonHandler::MatrixPosition::Retarder_2);
+        bh.addListener(*this, ButtonHandler::MatrixPosition::Retarder_3);
+        bh.addListener(*this, ButtonHandler::MatrixPosition::Retarder_4);
+        bh.addListener(*this, ButtonHandler::MatrixPosition::Retarder_5);
+        bh.addListener(*this, ButtonHandler::MatrixPosition::Retarder_6);
+        bh.addListener(*this, ButtonHandler::MatrixPosition::Scheibenwischer_1);
+        bh.addListener(*this, ButtonHandler::MatrixPosition::Scheibenwischer_2);
+        bh.addListener(*this, ButtonHandler::MatrixPosition::Scheibenwischer_3);
+        bh.addListener(*this, ButtonHandler::MatrixPosition::Scheinwerfer_A1);
+        bh.addListener(*this, ButtonHandler::MatrixPosition::Scheinwerfer_A2);
+        bh.addListener(*this, ButtonHandler::MatrixPosition::Scheinwerfer_I1);
+        bh.addListener(*this, ButtonHandler::MatrixPosition::Scheinwerfer_I2);
+        bh.addListener(*this, ButtonHandler::MatrixPosition::SystemInfo_ab);
+        bh.addListener(*this, ButtonHandler::MatrixPosition::SystemInfo_auf);
+        bh.addListener(*this, ButtonHandler::MatrixPosition::Tuer_1);
+        bh.addListener(*this, ButtonHandler::MatrixPosition::Tuer_2);
+        bh.addListener(*this, ButtonHandler::MatrixPosition::Tuer_3);
+        bh.addListener(*this, ButtonHandler::MatrixPosition::Tuer_Freigabe);
+        bh.addListener(*this, ButtonHandler::MatrixPosition::Tuer_Sperren_1);
+        bh.addListener(*this, ButtonHandler::MatrixPosition::Tuer_Sperren_2);
+        bh.addListener(*this, ButtonHandler::MatrixPosition::Wischwasser);
+        bh.addListener(*this, ButtonHandler::MatrixPosition::Zuendung_1);
+        bh.addListener(*this, ButtonHandler::MatrixPosition::Zuendung_2);
+        bh.addListener(*this, ButtonHandler::MatrixPosition::Zuendung_3);
     }
 
-        LampTester::LampTester()
+    LampTester::LampTester()
     {
         for (uint8_t idx = 0; idx < 64; idx++) {
             _state[idx] = false;
         }
     }
 
-    bool LampTester::setCurrentState(const uint8_t button, const bool state)
+    void LampTester::setCurrentState(const uint8_t button, const bool state, const bool prev_state)
     {
-        if (_state[button] == state) return false;
+        if (_state[button] == state) return;
 
         Serial.print(F("button "));
         Serial.print((int)button);
@@ -42,7 +86,6 @@ namespace BusDashboard {
         if (_lampposition >= LampHandler::NUMBER_OF_ICS * 8) _lampposition = 0;
         */
         _state[button] = state;
-        return true;
     }
 
 } // namespace BusDashboard class 


### PR DESCRIPTION
ButtonHandler now centrally detects changes in button states and notifies listeners of current AND previous state -> listener don't need to track the previous state themselves. This should make writing listeners more easy and lighter on RAM usage.

Also made addListener a little more robust by only allowing to subscribe to valid button positions